### PR TITLE
Mejora párrafos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,13 @@
 # Disclaimer para el Canal Compra-Venta
+
 Coders México sólo pone a disposición de los Usuarios un espacio virtual que les permite ponerse en comunicación mediante Internet para encontrar una forma de vender o comprar bienes y/o servicios. Coders México no es el propietario de los artículos ofrecidos, no tiene posesión de ellos ni los ofrece en venta. Coders México no interviene en el perfeccionamiento de las operaciones realizadas entre los Usuarios ni en las condiciones por ellos estipuladas para las mismas, por ello no será responsable respecto de la existencia, calidad, cantidad, estado, integridad o legitimidad de los bienes ofrecidos, adquiridos o enajenados por los Usuarios, así como de la capacidad para contratar de los Usuarios o de la veracidad de los Datos Personales por ellos ingresados. Cada Usuario conoce y acepta ser el exclusivo responsable por los artículos que publica para su venta y por las ofertas y/o compras que realiza.
+
 Debido a que Coders México no tiene ninguna participación durante todo el tiempo en que el artículo se publica para la venta, ni en la posterior negociación y perfeccionamiento del contrato definitivo entre las partes, no será responsable por el efectivo cumplimiento de las obligaciones asumidas por los Usuarios en el perfeccionamiento de la operación. El Usuario conoce y acepta que al realizar operaciones con otros Usuarios o terceros lo hace bajo su propio riesgo. En ningún caso Coders México será responsable por lucro cesante, o por cualquier otro daño y/o perjuicio que haya podido sufrir el Usuario, debido a las operaciones realizadas o no realizadas por artículos publicados a través de Coders México.
+
 Coders México recomienda actuar con prudencia y sentido común al momento de realizar operaciones con otros Usuarios. El Usuario debe tener presentes, además, los riesgos de contratar con menores o con personas que se valgan de una identidad falsa. Coders México NO será responsable por la realización de ofertas y/o operaciones con otros Usuarios basadas en la confianza depositada en el sistema o los Servicios brindados por Coders México.
+
 En caso que uno o más Usuarios o algún tercero inicien cualquier tipo de reclamo o acciones legales contra otro u otros Usuarios, todos y cada uno de los Usuarios involucrados en dichos reclamos o acciones eximen de toda responsabilidad a Coders México.
+
 El consejo de Administradores se reserva el derecho de suspender cualquier anuncio que rompa este Disclaimer.
 Todos los anuncios están sujetos al Código de Convivencia y el lenguaje de los anuncios deben de conformarse al mismo.
 


### PR DESCRIPTION
Hacía falta separar los párrafos para mejorar la lectura del texto.